### PR TITLE
allow custom errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Middleware for Express to adapt REST requests to GraphQL queries
 [![NPM](https://nodei.co/npm/rest-graphql.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/rest-graphql/)
 
 ## Motivation
-- You've built a GraphQL server, and it's ready to use. 
-- Not all your clients speak GraphQL. At the very least, legacy mobile clients can't make GraphQL requests. 
+- You've built a GraphQL server, and it's ready to use.
+- Not all your clients speak GraphQL. At the very least, legacy mobile clients can't make GraphQL requests.
 - You don't want to support both legacy and GraphQL client/server contracts simultaneously
 
 `rest-graphql` provides middleware that lets you define mappers from REST requests to graphql queries that fetch the same data, letting you normalize all client queries into something your GraphQL server can handle.
@@ -15,63 +15,97 @@ Install the package
 
 `npm install --save rest-graphql`
 
-Let's say you're building out a new profile page and have defined a GraphQL schema for it. You can fetch the necessary data via:
-```
-query ProfileQuery {
-  user(id: 1) {
-    profile_photo {
-      url
-    }
-    first_name
-    last_name
+Let's say you're building out a new profile page and have defined a GraphQL schema for it.  
+You can fetch the necessary data via:
+
+```graphql
+query PresidentQuery {
+  presidents {
+    name
   }
 }
 ```
 
-Create a new config and add the middleware to your express server:
-```
-import { createAdapter } from 'rest-graphql';
-import type { RestAdapterConfig } from 'rest-graphql'; // If you use flow
+Create a new RestAdapter and add the middleware to your express server:
 
-/**
- * This is the config that defines the mapping. It contains:
+```js
+import RestAdapter from 'rest-graphql';
+
+/* Build a new adapter
  *
- * path: string - the REST endpoint your client will hit. This follow expressjs route handling conventions
- * getQuery: (request) => string -  A mapping from the REST request to a GraphQL query
- * transformResponse: (response) => Object - Often the raw JSON from GraphQL doesn't make sense for the client, so perform any transform you want here
+ * isError        - detect is the graphql query has failed.
+ * transformError - transform the graphql errors into a rest response.
+ *
  */
-const profileConfig: RestAdapterConfig = {
-  path: '/profile/:id',
-  getQuery: request => `
-    user(id: ${request.params.id}) {
-      profile_photo {
-        url
-      }
-      first_name
-      last_name
-    }
-  `,
-  transformResponse: response => response.data.me,
-}
+const adapter = new RestAdapter({
+  isError:         (response) => !!response.errors,
+  transformError:  (response) => response.errors[0].__http_secret__,
+});
 
-const app = express();
-app.use(createAdapter([profileConfig])); // The rest-graphql middleware. It takes an array of RestAdapterConfigs
+/* Add endpoints to the adapter:
+ *
+ * path             - The REST endpoint.
+ * getQuery         - Function returning a Graphql Query as a String.
+ * transformSuccess - Function to transform successful query into a rest response.
+ */
+adapter.addEndpoint({
+  path: '/presidents',
+  getQuery: (request) => PRESIDENTS_QUERY,
+  transformSuccess: response => ({ status: 200, body: response.presidents }),
+});
 
-// Any other middleware or route handlers to process graphql requests.
+const graphql = express();
+
+graphql.use(adapter.app);
+graphql.use('/graphql', graphqlExpress(/* ... */));
 ```
 
 Which would result in:
 
-**Request:**
+**1. HTTP Request:**
 ```
-GET https://api.test.com/profile/9
+GET https://api.test.com/presidents
 ```
 
-**Response:** 
+**2. Graphql Query:**
 ```
-{ profile_photo: { url: "someurl" }, first_name: "Gaurav", last_name: "Kulkarni"}
+query PresidentQuery {
+  presidents {
+    name
+  }
+}
+```
+
+**3. Graphql Response:**
+```
+{
+  presidents: [
+    { name: "Jacques Chirac" },
+    { name: "George Washington" }
+  ]
+}
+```
+
+**4. HTTP Response:**
+```
+["Jacques Chirac", "George Washington"]
 ```
 
 ## Error Handling
 
-Error handling is currently built to work with request-promise and looks for any [StatusCodeErrors](https://github.com/request/promise-core/blob/master/lib/errors.js#L22) that are thrown and parses those.
+To transform Graphql query errors into the REST responses we recommend using something similar to
+[https://github.com/apollographql/apollo-server#options](apollo-server) formatError options. In the above example we format the HTTP errors like the following:
+
+```json
+{
+  "presidents": null,
+  "errors": [
+    {
+      "message": "Internal server error",
+      "__http_secret__": {
+        "status": 500,
+        "message": "Internal server error",
+      },
+    },
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ import RestAdapter from 'rest-graphql';
 
 /* Build a new adapter
  *
- * isError        - detect is the graphql query has failed.
- * transformError - transform the graphql errors into a rest response.
+ * isError        - Detect is the graphql query has failed.
+ * transformError - Transform the failed query response into a RestAdapterResponse.
  *
  */
 const adapter = new RestAdapter({
@@ -45,8 +45,8 @@ const adapter = new RestAdapter({
 /* Add endpoints to the adapter:
  *
  * path             - The REST endpoint.
- * getQuery         - Function returning a Graphql Query as a String.
- * transformSuccess - Function to transform successful query into a rest response.
+ * getQuery         - Function returning a Graphql query as a String.
+ * transformSuccess - Transform the successful query response into a RestAdapterResponse.
  */
 adapter.addEndpoint({
   path: '/presidents',
@@ -94,7 +94,7 @@ query PresidentQuery {
 ## Error Handling
 
 To transform Graphql query errors into the REST responses we recommend using something similar to
-[https://github.com/apollographql/apollo-server#options](apollo-server) formatError options. In the above example we format the HTTP errors like the following:
+[apollo-server](https://github.com/apollographql/apollo-server#options) formatError options. In the above example we format the HTTP errors like the following:
 
 ```json
 {
@@ -104,7 +104,9 @@ To transform Graphql query errors into the REST responses we recommend using som
       "message": "Internal server error",
       "__http_secret__": {
         "status": 500,
-        "message": "Internal server error",
+        "body": {
+          "message": "Internal server error"
+        }
       },
     },
   ]

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -1,35 +1,137 @@
 import express from 'express';
 import request from 'supertest';
-import { createAdapter, RestAdapterConfig } from '../index';
+import RestAdapter from '../index';
 
-const testQuery = `
-  query TestQuery {
-    user {
-      id
+const PRESIDENTS_QUERY = `
+  query PresidentQuery {
+    presidents {
       name
     }
   }
 `;
 
-const testConfig = {
-  path: '/user',
-  getQuery: (request) => testQuery,
-  transformResponse: response => response.user,
+const CHEESES_QUERY = `
+  query CheesesQuery {
+    cheeses {
+      name
+      location
+    }
+  }
+`;
+
+function setup(options = {}) {
+  const adapter = new RestAdapter({
+    isError:         (response) => !!response.errors,
+    transformError:  (response) => response.errors[0].__http_secret__,
+  });
+
+  adapter.addEndpoint({
+    path: '/presidents',
+    getQuery: (request) => PRESIDENTS_QUERY,
+    transformSuccess: response => ({ status: 200, body: response.presidents }),
+  });
+
+  adapter.addEndpoint({
+    path: '/cheeses',
+    getQuery: (request) => CHEESES_QUERY,
+    transformSuccess: response => ({ status: 200, body: response.cheeses }),
+  });
+
+  const app = express();
+
+  app.use(adapter.app);
+
+  app.use('/graphql', (req, res) => {
+    const response = options[req.body.query];
+    res.setHeader('Content-Type', 'application/json');
+    res.write(JSON.stringify(response));
+    res.end();
+  });
+
+  return { app };
 }
 
 describe('requests', () => {
-  const app = express();
-  app.use(createAdapter([testConfig]));
-  app.use('/graphql', (req, res) => {
-    return Promise.resolve(req.body.query).then(query => {
-      expect(query).toEqual(testQuery);
-      res.setHeader('Content-Type', 'application/json');
-      res.json({ user: { id: 1, name: 'test' } });
-      res.end();
+  describe('when the graphql return the query result', () => {
+    it('return the response', () => {
+      const { app } = setup({
+        [PRESIDENTS_QUERY]: {
+          presidents: [
+            { name: 'Jacques Chirac' },
+            { name: 'George Washington'},
+          ],
+        },
+        [CHEESES_QUERY]: {
+          cheeses: [
+            { name: 'Camembert' },
+            { name: 'Brie' },
+          ]
+        }
+      });
+
+      return request(app).get('/presidents').expect(200).expect(res => {
+        expect(JSON.parse(res.text)).toEqual([
+          { name: 'Jacques Chirac' },
+          { name: 'George Washington'},
+        ]);
+      });
+
+      return request(app).get('/cheeses').expect(200).expect(res => {
+        expect(JSON.parse(res.text)).toEqual([
+          { name: 'Camembert' },
+          { name: 'Brie'},
+        ]);
+      });
     });
   });
 
-  it('transforms requests', () => request(app).get('/user').expect(200).expect(res => {
-    expect(JSON.parse(res.text)).toEqual({ id: 1, name: 'test' });
-  }));
+  describe('when the graphql query errors ', () => {
+    describe('and the error is JSON', () => {
+      it('return the error', () => {
+        const { app } = setup({
+          [PRESIDENTS_QUERY]: {
+            presidents: null,
+            errors: [{
+              message: 'No presidents found',
+              __http_secret__: {
+                status: 404,
+                body: {
+                  message: 'No presidents found',
+                  code:    'monarchy',
+                }
+              },
+            }]
+          }
+        });
+
+        return request(app).get('/presidents').expect(404).expect(res => {
+          expect(JSON.parse(res.text)).toEqual({
+            message: 'No presidents found',
+            code:    'monarchy',
+          });
+        });
+      });
+    });
+
+    describe('and the error is text', () => {
+      it('return the error', () => {
+        const { app } = setup({
+          [CHEESES_QUERY]: {
+            presidents: null,
+            errors: [{
+              message: 'No cheeses found',
+              __http_secret__: {
+                status: 404,
+                body: "<html>No cheeses found</html>"
+              },
+            }]
+          }
+        });
+
+        return request(app).get('/cheeses').expect(404).expect(res => {
+          expect(res.text).toEqual("<html>No cheeses found</html>");
+        });
+      });
+    });
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,49 +1,61 @@
 /* @flow */
 import express from 'express';
 
-type RestAdapterConfig = {
-  path: string, 
-  getQuery: (request: express.Request) => string,
-  transformResponse: (response: Object) => Object,
+type RestAdapterConfigResponse = {
+  body: Object,
+  status: number,
 };
 
-export type { RestAdapterConfig };
+export type Config = {
+  isError: (response: Object) => boolean,
+  transformError: (response: Object) => RestAdapterConfigResponse,
+};
 
-export const createAdapter = (configs: Array<RestAdapterConfig>) => {
-  const app = express();
+export type EndpointConfig = {
+  path: string,
+  getQuery(req: express.Request): string,
+  transformSuccess: (response: Object) => RestAdapterConfigResponse,
+};
 
-  configs.map(config => {
-    app.get(config.path, (req, res, next) => {
-      const query = config.getQuery(req);
-      req.url = '/graphql';
+export default class RestAdapter {
+  config: Config
+  app: *
+
+  constructor(config: Config) {
+    this.config = config;
+    this.app = express();
+  }
+
+  addEndpoint(endpointConfig: EndpointConfig) {
+    this.app.get(endpointConfig.path, (req: express.Request, res: express.Response, next: Function) => {
+      req.url    = '/graphql';
       req.method = 'POST';
-      req.body = { query };
+      req.body   = { query: endpointConfig.getQuery(req) };
 
-      // Replace response writer with writer that transforms to a REST compatible response
-      const write = res.write;
-      res.write = function transformedWrite(string) {
-        const writeError = err => {
-          const [status, message] = err.message.split(' - ');
-          res.status(status);
-          write.call(this, message);
-        };
+      const config = this.config;
+      const write  = res.write;
 
-        const messageJSON = JSON.parse(string);
-        if (messageJSON.errors) {
-          writeError(messageJSON.errors[0]);
+      res.write = function(grapqhRawResponse) {
+        const grapqhResponse = JSON.parse(grapqhRawResponse);
+        const isError = config.isError(grapqhResponse);
+
+        const response = isError
+          ? config.transformError(grapqhResponse)
+          : endpointConfig.transformSuccess(grapqhResponse);
+
+        if (response.body instanceof Object) {
+          res.setHeader('Content-Type', 'application/json');
         } else {
-          try {
-            const transformedJSON = config.transformResponse(messageJSON);
-            write.call(this, JSON.stringify(transformedJSON));
-          } catch (err) {
-            writeError(err);
-          }
+          res.setHeader('Content-Type', 'text/html');
         }
+
+        const body = response.body instanceof Object ? JSON.stringify(response.body) : response.body;
+
+        res.status(response.status);
+        write.call(this, body);
       };
 
       next();
     });
-  });
-
-  return app;
-};
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,32 @@
 /* @flow */
 import express from 'express';
 
-type RestAdapterConfigResponse = {
+type RestAdapterResponse = {
   body: Object,
   status: number,
 };
 
-export type Config = {
+export type RestAdapterConfig = {
   isError: (response: Object) => boolean,
-  transformError: (response: Object) => RestAdapterConfigResponse,
+  transformError: (response: Object) => RestAdapterResponse,
 };
 
-export type EndpointConfig = {
+export type RestAdapterEndpointConfig = {
   path: string,
   getQuery(req: express.Request): string,
-  transformSuccess: (response: Object) => RestAdapterConfigResponse,
+  transformSuccess: (response: Object) => RestAdapterResponse,
 };
 
 export default class RestAdapter {
-  config: Config
+  config: RestAdapterConfig
   app: *
 
-  constructor(config: Config) {
+  constructor(config: RestAdapterConfig) {
     this.config = config;
     this.app = express();
   }
 
-  addEndpoint(endpointConfig: EndpointConfig) {
+  addEndpoint(endpointConfig: RestAdapterEndpointConfig) {
     this.app.get(endpointConfig.path, (req: express.Request, res: express.Response, next: Function) => {
       req.url    = '/graphql';
       req.method = 'POST';


### PR DESCRIPTION
- removes the `request-promise` [dependency](https://github.com/remind101/rest-graphql/blob/master/src/index.js#L26)
- changed the public API.

```js
import RestAdapter from 'rest-graphql';

/* Build a new adapter
 *
 * isError        - Detect is the graphql query has failed.
 * transformError - Transform the failed query response into a RestAdapterResponse.
 *
 */
const adapter = new RestAdapter({
  isError:         (response) => !!response.errors,
  transformError:  (response) => response.errors[0].__http_secret__,
});

/* Add endpoints to the adapter:
 *
 * path             - The REST endpoint.
 * getQuery         - Function returning a Graphql query as a String.
 * transformSuccess - Transform the successful query response into a RestAdapterResponse.
 */
adapter.addEndpoint({
  path: '/presidents',
  getQuery: (request) => PRESIDENTS_QUERY,
  transformSuccess: response => ({ status: 200, body: response.presidents }),
});

const graphql = express();

graphql.use(adapter.app);
graphql.use('/graphql', graphqlExpress(/* ... */));
```