### PR TITLE
Fix spelling of graphql in addEndpoint function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,13 +35,13 @@ export default class RestAdapter {
       const config = this.config;
       const write  = res.write;
 
-      res.write = function(grapqhRawResponse) {
-        const grapqhResponse = JSON.parse(grapqhRawResponse);
-        const isError = config.isError(grapqhResponse);
+      res.write = function(graphqlRawResponse) {
+        const graphqlResponse = JSON.parse(graphqlRawResponse);
+        const isError = config.isError(graphqlResponse);
 
         const response = isError
-          ? config.transformError(grapqhResponse)
-          : endpointConfig.transformSuccess(grapqhResponse);
+          ? config.transformError(graphqlResponse)
+          : endpointConfig.transformSuccess(graphqlResponse);
 
         if (response.body instanceof Object) {
           res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
Adjusts the spelling of `grapqhResponse` and `grapqhRawResponse` to be `graphqlReponse` and `graphqlRawResponse` respectively. This is to make it a little easier to search for the term `graphql` in the codebase.